### PR TITLE
Update lab2.rst

### DIFF
--- a/docs/class12/module3/lab2/lab2.rst
+++ b/docs/class12/module3/lab2/lab2.rst
@@ -199,7 +199,7 @@ you ran.
 .. code-block:: bash
    :caption: Jumphost Annotation 
 
-   kubectl annotate deploy/roller-deploy -n test kubernetes.io/change-cause="container image to nginx:1.24"
+   kubectl annotate deploy/roller-deploy -n test kubernetes.io/change-cause="rollback container image to nginx:1.20"
 
 Now if you run the history command again, you'll notice your revision note is included.
 


### PR DESCRIPTION
The previous steps have the student rolling back to NGINX 1.20. The annotation exercise, however, labels this step in the rollout history as going to 1.24, which can be confusing to the student.