### PR TITLE
Update lab1.rst

### DIFF
--- a/docs/class12/module3/lab1/lab1.rst
+++ b/docs/class12/module3/lab1/lab1.rst
@@ -140,19 +140,21 @@ Feel free to run some Linux commands such as
 
 To exit the shell, type **exit**
 
+For multi-container pods, you will need to include the -c flag to specify the container to exec into. (For single-container pods, the -c flag is optional.)
+
+.. code-block:: bash 
+   :caption: Shell Multi-Container
+
+   kubectl exec -it <pod_name> -c <container_name> -n <namespace> -- /bin/bash
+
+How would you use the -c flag to exec into the container running in *testpod*?
+
 But you don't have to access the shell to run your commands, you can *pass* the command to the shell.
 
 .. code-block:: bash
    :caption: Shell
 
    kubectl exec -it testpod -n test -- ls -la
-
-Example for multi-container pod:
-
-.. code-block:: bash 
-   :caption: Shell Multi-Container
-
-   kubectl exec -it <pod_name> -c <container_name> -n <namespace> -- /bin/bash
 
 DNS Utils
 ---------


### PR DESCRIPTION
Reversed order of two examples (running a command without accessing the shell, and running a command when the pod includes more than one container). I believe this is clearer to the student. I also added language to let the student know that explicitly specifying the container can also be done in single-container pods, but is optional.