### PR TITLE
Typos and reference fixes

### DIFF
--- a/docs/class15/lab1/lab1.md
+++ b/docs/class15/lab1/lab1.md
@@ -4,7 +4,7 @@
 
 # Understanding F5 AI Gateway components and preparing the lab
 [AI Gateway solution components](#there-are-two-solution-components-to-aigw)    
-[Starting the ab](#starting-the-lab)
+[Starting the lab](#starting-the-lab)
 
 
 # There are two solution components to AIGW:  

--- a/docs/class15/lab7/lab7.rst
+++ b/docs/class15/lab7/lab7.rst
@@ -141,7 +141,7 @@ using again ``prompt-injection`` processor.
 
    You will see that this time **AI Gateway** is blocking it.
 
-   .. image:: /lab7/images/01.png
+   .. image:: lab7/images/01.png
 
 6. Inspect the AI Gateway logs. You will see similar logs as bellow. The
    processor has blocked the request with a prompt injection confidence


### PR DESCRIPTION
Fixing a typo - 'Starting the ab' in lab1.md