### PR TITLE
Removed check-the-docs badge from main readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ F5 Agility Lab Template
 
 [![Issues](https://img.shields.io/github/issues/f5devcentral/f5-agility-labs-nginx.svg)](https://github.com/f5devcentral/f5-agility-labs-nginx/issues)
 [![Build the Docs](https://github.com/f5devcentral/f5-agility-labs-nginx/actions/workflows/build-the-docs.yml/badge.svg)](https://github.com/f5devcentral/f5-agility-labs-nginx/actions/workflows/build-the-docs.yml)
-[![Check the Docs](https://github.com/f5devcentral/f5-agility-labs-template/actions/workflows/check-the-docs.yml/check.svg)](https://github.com/f5devcentral/f5-agility-labs-template/actions/workflows/check-the-docs.yml)
 
 Introduction
 ------------


### PR DESCRIPTION
I'm removing this badge because this Github Action has not been implemented. If it does in future, it could be added again but for now, it's a nuisance.