### PR TITLE
Update lab1.rst

### DIFF
--- a/docs/class2/module3/lab/lab1.rst
+++ b/docs/class2/module3/lab/lab1.rst
@@ -19,14 +19,14 @@ we will enable Rate limiting to our Appster service
 
    Uncomment the line with
    the \ `limit_req <https://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req>`__ directive,
-   found near the top of the file, this is in the \ ``http`` context,
-   outside the ``server`` context and change the ``10000`` to ``10``:
+   found near the top of the file. This is in the \ ``http`` context,
+   outside the ``server`` context. Be sure the rate is set to ``10``:
 
    .. code-block:: ini
 
       # Rate limit
       # Uncomment lines below to enable here
-      limit_req $binary_remote_addr zone=limit_me:1m rate=10000r/s;
+      limit_req $binary_remote_addr zone=limit_me:1m rate=10r/s;
 
    This line defines our rate-limiting rule:
 
@@ -42,8 +42,7 @@ we will enable Rate limiting to our Appster service
      store about 16,000 IP addresses (4 bytes for IPv4 addresses, stored
      state occupies 128 bytes on 64-bit platforms.)
    - **rate** - The number of requests per second
-     (\`**r/s\`**) or requests per minute (\ ``r/m``). It is initially
-     set to ``10000r/s`` but we changed it to ``10r/s``
+     (\`**r/s\`**) or requests per minute (\ ``r/m``). We set it to ``10r/s``
 
 3. Now we can enable the rate-limiting URL on the root location (``/``).
    In the same file, ``www.appster.com.conf`` , also uncomment the lines


### PR DESCRIPTION
In the actual lab (from the "AppWorld 2025 - NGINX Plus 301: CI/CD with NGINX+ (and Gitlab) (version 1)" blueprint), the www.appster.com.conf file contains the line, # limit_req $binary_remote_addr zone=limit_me:1m rate=10r/s;

In this version of the blueprint, It is initially set to 10, not 10000. This PR fixes the text that suggests otherwise (and would be a potential source of confusion for the students).